### PR TITLE
Remove Background Fetch Integration from App

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,17 +6,29 @@ import {AppRegistry, LogBox, Text, TextInput} from 'react-native';
 
 import {DEMO_MODE} from '@env';
 
-import {initBackgroundFetch} from '@utils/BackgroundOperations/backgroundFetch';
-
 import App from './App';
 import {name as appName} from './app.json';
 import {registerBackgroundMessaging} from './src/utils/Messaging/PushNotifications/fcm';
+import {AppState} from 'react-native';
+import {performPeriodicOperations} from '@utils/AppOperations';
+
 
 if (DEMO_MODE === 'true') {
   LogBox.ignoreAllLogs();
 }
 
-initBackgroundFetch();
+
+useEffect(() => {
+  const subscription = AppState.addEventListener('change', (nextAppState) => {
+    if (nextAppState === 'active') {
+      // manually triggering periodic operations
+      performPeriodicOperations();
+    }
+  });
+
+  return () => subscription.remove();
+}, []);
+
 
 /**
  * Prevents accessibility text from expanding beyond what the app can comfortably render

--- a/package.json
+++ b/package.json
@@ -4,7 +4,18 @@
   "private": false,
   "license": "Apache-2.0",
   "description": "A consent-based communication app that uses no persistent identifiers",
-  "keywords": ["numberless", "port", "communication", "messaging", "mobile",  "consent", "privacy", "secure", "identifierless", "react-native"],
+  "keywords": [
+    "numberless",
+    "port",
+    "communication",
+    "messaging",
+    "mobile",
+    "consent",
+    "privacy",
+    "secure",
+    "identifierless",
+    "react-native"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/Numberless-Inc/port-mobile"
@@ -56,7 +67,6 @@
     "react-native": "0.78.2",
     "react-native-audio-recorder-player": "^3.6.6",
     "react-native-autolink": "^4.2.0",
-    "react-native-background-fetch": "^4.2.1",
     "react-native-blob-util": "^0.19.6",
     "react-native-bootsplash": "^6.3.4",
     "react-native-cloud-storage": "^2.2.2",

--- a/src/utils/BackgroundOperations/backgroundFetch.ts
+++ b/src/utils/BackgroundOperations/backgroundFetch.ts
@@ -1,33 +1,19 @@
-import BackgroundFetch from 'react-native-background-fetch';
 
 import {performPeriodicOperations} from '@utils/AppOperations';
 
 export async function initBackgroundFetch() {
-  // Initialize BackgroundFetch only once when component mounts.
-  const status = await BackgroundFetch.configure(
-    {minimumFetchInterval: 15},
-    allottedBackgroundTime,
-    onTimeout,
-  );
 
-  if (status === 2) {
-    console.log('[BackgroundFetch] Available');
-  } else {
-    console.log('[BackgroundFetch] Unavailable, status: ', status);
+  console.log('[BackgroundFetch] Disabled. Manually trigger operations if needed.');
+}
+
+export async function manuallyTriggerPeriodicOperations() {
+  console.log('[Manually triggering background operations]');
+  try {
+    await performPeriodicOperations();
+    console.log('[Manual operation completed]');
+  } catch (err) {
+    console.error('[Manual operation failed]', err);
   }
-}
-
-async function allottedBackgroundTime(taskId: string) {
-  console.log('[Starting background fetch]: ', taskId);
-  await performPeriodicOperations();
-  console.log('[Completed background fetch withing allotted time]: ', taskId);
-  BackgroundFetch.finish(taskId);
-}
-
-async function onTimeout(taskId: string) {
-  console.warn('[Did not finish background fetch in allotted time]: ', taskId);
-  // Add cleanup here
-  BackgroundFetch.finish(taskId);
 }
 
 // On android force background fetch using the following while debugging

--- a/yarn.lock
+++ b/yarn.lock
@@ -9913,11 +9913,6 @@ react-native-autolink@^4.2.0:
   dependencies:
     autolinker "^3.16.2"
 
-react-native-background-fetch@^4.2.1:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/react-native-background-fetch/-/react-native-background-fetch-4.2.3.tgz#d952613afccbc64bc33f17ff402baa1540133d2a"
-  integrity sha512-JC20TejQZfQk5DueXwK/HPpJNB7WZ3rMmyzHVKF+F14vHKf/RzUMJf3q8WXZ4rs5iPiHjbMkadwXGAPWYe5g6w==
-
 react-native-blob-util@^0.19.6:
   version "0.19.8"
   resolved "https://registry.yarnpkg.com/react-native-blob-util/-/react-native-blob-util-0.19.8.tgz#c31aeeebcbbbb1c10faec4346955ed9374a1d9d3"


### PR DESCRIPTION
This PR removes the usage of react-native-background-fetch from the app. The following changes were made:

Replaced background fetch logic with a manual performPeriodicOperations trigger.
Removed any dependency on automatic periodic tasks.